### PR TITLE
Make the pretty_print output a bit wider.

### DIFF
--- a/lib/stud/benchmark.rb
+++ b/lib/stud/benchmark.rb
@@ -110,7 +110,7 @@ module Stud
         puts sorted.collect { |lower_bound, count|
           #puts lower_bound
           percent = (count / Float(total))
-          "%30s: %s" % [lower_bound, (TICKS.last * (50 * percent).ceil)]
+          "%40s: %s" % [lower_bound, (TICKS.last * (50 * percent).ceil)]
         }.join("\n")
 
       end # def pretty_print


### PR DESCRIPTION
I've got some **very small** things to measure that may become large. We're talking numbers like so:

`ruby 1.9.3: avg: 4.609999999999991e-05 stddev: 0.0002573576440616381`

This makes the pretty printer actually pretty for my numbers. Let me know if it's too wide!
