### PR TITLE
pass :final value to output flush method

### DIFF
--- a/lib/stud/buffer.rb
+++ b/lib/stud/buffer.rb
@@ -216,9 +216,9 @@ module Stud
         @buffer_state[:outgoing_items].each do |group, events|
           begin
             if group.nil?
-              flush(events)
+              flush(events,final)
             else
-              flush(events, group)
+              flush(events, group, final)
             end
 
             @buffer_state[:outgoing_items].delete(group)


### PR DESCRIPTION
use full as a hint for specific output final flush on teardown
see https://github.com/logstash/logstash/pull/419 for how it is used in redis
