### PR TITLE
Add license to gemspec.

### DIFF
--- a/stud.gemspec
+++ b/stud.gemspec
@@ -1,6 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name = "stud"
   spec.version = "0.0.22"
+  spec.license = "MIT"
   spec.summary = "stud - common code techniques"
   spec.description = "small reusable bits of code I'm tired of writing over " \
     "and over. A library form of my software-patterns github repo."


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com/ruby/stud/0.0.22) and for us the license information is very important. It would be extremely helpful if this information would be available in the gemspec. Many thanks. Robert.
