### PR TITLE
Prevent errors when stopping an already killed task

### DIFF
--- a/lib/stud/interval.rb
+++ b/lib/stud/interval.rb
@@ -41,7 +41,12 @@ module Stud
   def self.stop!(target = Thread.current)
     # setting/getting threalocal var is thread safe in JRuby
     target[STUD_STOP_REQUESTED] = true
-    target.wakeup
+    begin
+      target.wakeup
+    rescue ThreadError => e
+      # The thread is dead, so there's nothing to do. 
+      # There's no race-free way to detect this sadly
+    end
     nil
   end
 

--- a/spec/stud/task_spec.rb
+++ b/spec/stud/task_spec.rb
@@ -30,5 +30,20 @@ describe Stud::Task do
       insist { task.stop? } == true
       insist { Time.now - start_time } < 2
     end
+
+    it "should not error stopping twice" do
+      task = Stud::Task.new do
+        sleep 100
+        Stud.stop?
+      end
+
+      sleep 1
+
+      task.stop!
+
+      expect do
+        task.stop!
+      end.not_to raise_error()
+    end
   end
 end


### PR DESCRIPTION
The `stop!` method should be idempotent. It can currently die if you accidentally call `stop!` twice.