### PR TITLE
Update temporary_spec.rb - exists is deprecated and removed as of Ruby 3.2, use exist

### DIFF
--- a/spec/stud/temporary_spec.rb
+++ b/spec/stud/temporary_spec.rb
@@ -41,7 +41,7 @@ describe Stud::Temporary do
       it "should clean up after the block closes" do
         path = ""
         file { |fd| path = fd.path }
-        reject { File }.exists?(path)
+        reject { File }.exist?(path)
       end
     end # with a block
   end # #file


### PR DESCRIPTION
exists is deprecated and doesn't work on Ruby 3.2 and later. It should be exist now.